### PR TITLE
Add drug names to cdb

### DIFF
--- a/dutch-umls_to_concept-table.ipynb
+++ b/dutch-umls_to_concept-table.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2511,122 +2511,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "#In case you want to begin from here, load existing concept table:\n",
-    "\n",
     "#umls_snomed_tui_filtered = pd.read_csv(\"04_ConceptDB/umls-dutch_v1.8.csv\", dtype=str)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>cui</th>\n",
-       "      <th>name</th>\n",
-       "      <th>ontologies</th>\n",
-       "      <th>name_status</th>\n",
-       "      <th>type_ids</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>C2348241</td>\n",
-       "      <td>alcaftadine</td>\n",
-       "      <td>ATC</td>\n",
-       "      <td>IN</td>\n",
-       "      <td>T121</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>C2348241</td>\n",
-       "      <td>alcaftadine</td>\n",
-       "      <td>ATC</td>\n",
-       "      <td>IN</td>\n",
-       "      <td>T109</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>C0039644</td>\n",
-       "      <td>tetracycline</td>\n",
-       "      <td>ATC</td>\n",
-       "      <td>IN</td>\n",
-       "      <td>T195</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>C0039644</td>\n",
-       "      <td>tetracycline</td>\n",
-       "      <td>ATC</td>\n",
-       "      <td>IN</td>\n",
-       "      <td>T109</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>C0039943</td>\n",
-       "      <td>thioridazine</td>\n",
-       "      <td>ATC</td>\n",
-       "      <td>IN</td>\n",
-       "      <td>T121</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        cui          name ontologies name_status type_ids\n",
-       "0  C2348241   alcaftadine        ATC          IN     T121\n",
-       "1  C2348241   alcaftadine        ATC          IN     T109\n",
-       "2  C0039644  tetracycline        ATC          IN     T195\n",
-       "3  C0039644  tetracycline        ATC          IN     T109\n",
-       "4  C0039943  thioridazine        ATC          IN     T121"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Retrieve Dutch UMLS concepts\n",
-    "query = \"\"\"\n",
-    "SELECT distinct MRCONSO.cui, str as name, tty as name_status, sab as ontologies, tui as type_ids\n",
-    "FROM MRCONSO\n",
-    "LEFT JOIN MRSTY ON MRSTY.cui = MRCONSO.cui\n",
-    "WHERE SAB in ('ATC','DRUGBANK','RXNORM')\n",
-    "\"\"\"\n",
-    "df_drugs = pd.read_sql_query(query, con=connection)\n",
-    "df_drugs.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -2711,20 +2606,26 @@
        "4  C0039943  thioridazine          IN        ATC     T121"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#Swap columns name_status and ontologies to match earlier generated dataframe\n",
-    "df_drugs=df_drugs.reindex(columns=['cui','name','name_status','ontologies','type_ids'])\n",
+    "# Retrieve Dutch UMLS concepts\n",
+    "query = \"\"\"\n",
+    "SELECT distinct MRCONSO.cui, str as name, tty as name_status, sab as ontologies, tui as type_ids\n",
+    "FROM MRCONSO\n",
+    "LEFT JOIN MRSTY ON MRSTY.cui = MRCONSO.cui\n",
+    "WHERE SAB in ('ATC','DRUGBANK','RXNORM')\n",
+    "\"\"\"\n",
+    "df_drugs = pd.read_sql_query(query, con=connection)\n",
     "df_drugs.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -2748,7 +2649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -2840,7 +2741,7 @@
        "4  SNOMEDCT-NL     T131  "
       ]
      },
-     "execution_count": 19,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Extended the dutch-umls_to_concept-table notebook to make it easy to add the drug names to the concept database.