### PR TITLE
v1.10: Fix mistake with TUI filtering after adding drugs

### DIFF
--- a/dutch-umls_to_concept-table.ipynb
+++ b/dutch-umls_to_concept-table.ipynb
@@ -24,7 +24,7 @@
    "outputs": [],
    "source": [
     "# Set output version of the generated UMLS dutch concept table\n",
-    "UMLS_DUTCH_VERSION = 'v1.9'\n",
+    "UMLS_DUTCH_VERSION = 'v1.10'\n",
     "\n",
     "# Set input version of SNOMED to append to UMLS terms\n",
     "SNOMED_DUTCH_VERSION = 'v1.2'"
@@ -1903,26 +1903,6 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "fc4a6225",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create dictionary of UMLS concepts that are in our existing Dutch name table\n",
-    "dutch_umls_ids=dutch_umls.groupby('cui')['str'].apply(list).to_dict()\n",
-    "\n",
-    "# Create a set with all Dutch UMLS names in lowercase\n",
-    "dutch_umls_names_lowercase = set()\n",
-    "for cui in dutch_umls_ids:\n",
-    "    for value in dutch_umls_ids[cui]:\n",
-    "        dutch_umls_names_lowercase.add(value.lower())\n",
-    "        \n",
-    "# Also create a column with the lowercase names, which allows for easy comparison \n",
-    "snomed_dutch['lowercase_str'] = snomed_dutch.str.str.lower()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
    "id": "a09beb7f",
    "metadata": {},
    "outputs": [
@@ -1942,6 +1922,8 @@
     "    if snomed_id in unambiguous_mapping_ids:\n",
     "        cui = snomed_to_umls_mapping[snomed_id][0]\n",
     "        snomed_names_to_add.append([cui, row['str'], row['tty']])\n",
+    "        \n",
+    "# Create lists to fill with SNOMED names and their UMLS CUIs\n",
     "snomed_names_to_add = list()\n",
     "snomed_names_to_skip = list()\n",
     "\n",
@@ -1963,7 +1945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "id": "6593b9fd",
    "metadata": {},
    "outputs": [
@@ -2043,7 +2025,7 @@
        "4  C0230364    structuur van posterieure carpale regio   P  SNOMEDCT_NL"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2066,7 +2048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "id": "fb03eaa7",
    "metadata": {},
    "outputs": [
@@ -2096,7 +2078,6 @@
        "      <th>tty</th>\n",
        "      <th>tui</th>\n",
        "      <th>sab</th>\n",
-       "      <th>lowercase_str</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -2107,7 +2088,6 @@
        "      <td>P</td>\n",
        "      <td>afwijkende morfologie</td>\n",
        "      <td>SNOMEDCT_NL</td>\n",
-       "      <td>abces</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>132978</th>\n",
@@ -2116,19 +2096,18 @@
        "      <td>P</td>\n",
        "      <td>aandoening</td>\n",
        "      <td>SNOMEDCT_NL</td>\n",
-       "      <td>abces</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "              cui    str tty                    tui          sab lowercase_str\n",
-       "47875    44132006  abces   P  afwijkende morfologie  SNOMEDCT_NL         abces\n",
-       "132978  128477000  abces   P             aandoening  SNOMEDCT_NL         abces"
+       "              cui    str tty                    tui          sab\n",
+       "47875    44132006  abces   P  afwijkende morfologie  SNOMEDCT_NL\n",
+       "132978  128477000  abces   P             aandoening  SNOMEDCT_NL"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2139,8 +2118,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "id": "7ee2ed30",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['C0000833']"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "snomed_to_umls_mapping['44132006']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "42170bb6",
    "metadata": {},
    "outputs": [
     {
@@ -2155,33 +2155,12 @@
     }
    ],
    "source": [
-    "snomed_to_umls_mapping['44132006']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "id": "42170bb6",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['C0000833']"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
     "snomed_to_umls_mapping['128477000']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "id": "95efe9f1",
    "metadata": {},
    "outputs": [
@@ -2237,7 +2216,7 @@
        "128226  C0000833  abces   P  SNOMEDCT_NL"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2248,7 +2227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "id": "d39169d5",
    "metadata": {},
    "outputs": [
@@ -2304,7 +2283,7 @@
        "45877  C0000833  abces   P  SNOMEDCT_NL"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2326,7 +2305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "id": "526f1b84",
    "metadata": {},
    "outputs": [
@@ -2346,7 +2325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "id": "d74b98d8",
    "metadata": {},
    "outputs": [
@@ -2366,7 +2345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "id": "e75cc86e",
    "metadata": {},
    "outputs": [
@@ -2588,7 +2567,7 @@
        "19  MSHDUT|SNOMEDCT_NL  "
       ]
      },
-     "execution_count": 37,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2602,7 +2581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "id": "4e721004",
    "metadata": {},
    "outputs": [
@@ -2722,7 +2701,7 @@
        "240  C0000820           therapeutische abortus   A           MDRDUT"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2742,7 +2721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "id": "6c9f4ce5",
    "metadata": {},
    "outputs": [
@@ -2798,7 +2777,7 @@
        "349584  C0678215  bleek   A       MDRDUT"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2815,7 +2794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "id": "b1c96ca5",
    "metadata": {},
    "outputs": [
@@ -2847,7 +2826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "id": "667c8d5a",
    "metadata": {},
    "outputs": [
@@ -2927,7 +2906,7 @@
        "4  C0000215                                       2,4,5-T   A  SNOMEDCT_NL"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2938,7 +2917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "id": "bcb92c5d",
    "metadata": {},
    "outputs": [
@@ -3034,7 +3013,7 @@
        "6  C0011206   delier   P  UMCU"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3046,7 +3025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "id": "89a6a53d",
    "metadata": {},
    "outputs": [
@@ -3076,7 +3055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 43,
    "id": "6f7b965b",
    "metadata": {},
    "outputs": [
@@ -3144,7 +3123,7 @@
        "4  C0175815  T104"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3160,7 +3139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 44,
    "id": "0c741fdf",
    "metadata": {},
    "outputs": [
@@ -3403,7 +3382,7 @@
        "19  T109  "
       ]
      },
-     "execution_count": 45,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3425,7 +3404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 45,
    "id": "23b21b41",
    "metadata": {},
    "outputs": [
@@ -3511,7 +3490,7 @@
        "552  C0001153                        acomys   A  MSHDUT  T015"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3549,7 +3528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 46,
    "id": "1eeaf3fd",
    "metadata": {},
    "outputs": [
@@ -3572,7 +3551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "id": "670b7eda",
    "metadata": {},
    "outputs": [
@@ -3591,7 +3570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 48,
    "id": "7a8b3a34",
    "metadata": {},
    "outputs": [
@@ -3747,7 +3726,7 @@
        "[644121 rows x 5 columns]"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3767,7 +3746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 49,
    "id": "87984b22",
    "metadata": {
     "scrolled": true
@@ -3862,7 +3841,7 @@
        "4  SNOMEDCT_NL  T131|T109  "
       ]
      },
-     "execution_count": 50,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3883,7 +3862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 50,
    "id": "97470723",
    "metadata": {},
    "outputs": [],
@@ -3894,7 +3873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 51,
    "id": "2063f5c0",
    "metadata": {},
    "outputs": [
@@ -3968,7 +3947,7 @@
        "4  C0041037  trimetazidine        ATC"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3986,7 +3965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 52,
    "id": "5c8f68ae",
    "metadata": {},
    "outputs": [],
@@ -3997,7 +3976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 53,
    "id": "d965c9ba",
    "metadata": {},
    "outputs": [
@@ -4151,7 +4130,7 @@
        "[824193 rows x 4 columns]"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4171,7 +4150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 54,
    "id": "18a83a34",
    "metadata": {},
    "outputs": [
@@ -4180,8 +4159,8 @@
      "output_type": "stream",
      "text": [
       "Number of rows containing TUIs: 885598\n",
-      "Number of rows filtering TUIs: 881605\n",
-      "Number of rows after merging TUIs in single value: 820856\n"
+      "Number of rows filtering TUIs: 885101\n",
+      "Number of rows after merging TUIs in single value: 824112\n"
      ]
     },
     {
@@ -4209,7 +4188,7 @@
        "      <th>name</th>\n",
        "      <th>name_status</th>\n",
        "      <th>ontologies</th>\n",
-       "      <th>tui</th>\n",
+       "      <th>type_ids</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -4400,7 +4379,7 @@
        "18  C0000379                 3,4-methylenedioxyamphetamine           A   \n",
        "19  C0000379                                           MDA           A   \n",
        "\n",
-       "     ontologies        tui  \n",
+       "     ontologies   type_ids  \n",
        "0        RXNORM  T121|T109  \n",
        "1   SNOMEDCT_NL  T131|T109  \n",
        "2   SNOMEDCT_NL  T131|T109  \n",
@@ -4423,7 +4402,7 @@
        "19     DRUGBANK  T109|T131  "
       ]
      },
-     "execution_count": 55,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4434,6 +4413,7 @@
     "print(f'Number of rows containing TUIs: {dutch_umls_snomed_drugs.shape[0]}')\n",
     "\n",
     "# Remove TUIs\n",
+    "rows_to_remove = dutch_umls_snomed_drugs[dutch_umls_snomed_drugs.tui.isin(tuis_to_remove)].index\n",
     "dutch_umls_snomed_drugs = dutch_umls_snomed_drugs.drop(dutch_umls_snomed_drugs.index[rows_to_remove])\n",
     "print(f'Number of rows filtering TUIs: {dutch_umls_snomed_drugs.shape[0]}')\n",
     "\n",
@@ -4459,7 +4439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 55,
    "id": "4e8d84e6",
    "metadata": {},
    "outputs": [],
@@ -4470,7 +4450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 56,
    "id": "f279ad5f",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
- Now correctly identify rows to remove during TUI filtering after adding drugnames
- Removed a redundant codeblock that was used for <= v1.8

## Mantra GSC evaluation
| Dataset         | UMLS dutch | Other changes              | F1 by char | F1 by cui |
|-----------------|------------|----------------------------|------------|-----------|
| Nlwiki          | v1.8       |                            | 0.585      | 0.526     |
| Nlwiki+Ntvg+Dcc | v1.8       |                            | 0.588      | 0.524     |
| Nlwiki+Ntvg+Dcc | v1.8+drugs |                            | 0.609      | 0.552     |
| Nlwiki+Ntvg+Dcc | v1.8+drugs | Diacritics fix             | 0.616      | 0.549     |
| Nlwiki+Ntvg+Dcc | v1.8+drugs | Above & uppercase fixes | 0.626      | 0.561     |
| Nlwiki+Ntvg+Dcc | v1.9+drugs | Above fix | 0.632      | 0.564     |
| Nlwiki+Ntvg+Dcc | v1.10+drugs | Above & TUI filtering fixes | 0.628      | 0.557     |