### PR TITLE
Update UMLS concept processing; upgrade SNOMED; upgrade UMLS

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -4,8 +4,8 @@ MYSQL_HOST=127.0.0.1
 MYSQL_PORT=3306
 MYSQL_DATABASE=umls
 
-# Location where the UMLS subset files are that you just created with MetamorphoSys
-SRC_FILE_DIR=<local_path_to_02_ExtractSubset>
+# Location of the UMLS subset created with MetamorphoSys
+SRC_FILE_DIR=./02_ExtractSubset/
 
-# Location where you want to save your MySQL UMLS DB on your local filesystem
-UMLS_DB_DIR=<local_path_to_03_SqlDB>
+# Location to save the MySQL UMLS DB on the local filesystem
+UMLS_DB_DIR=./03_SqlDB/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dutch Medical Concepts
-This repository contains instructions and code to create a subset of Dutch medical concepts from UMLS, which includes MeSH, MedDRA, ICD-10 and ICPC, and SNOMED CT concepts. By combining Dutch names from UMLS, SNOMED CT and English drug names, a table of primary names, synonyms and abbreviations commonly used in Dutch medical language is generated: ~800,000 names in ~300,000 concepts. The concept table can be used for named entity recognition and linking, such as [MedCAT](https://github.com/CogStack/MedCAT), on Dutch medical text.
+This repository contains instructions and code to create a subset of Dutch medical names concepts from UMLS, which includes MeSH, MedDRA, ICD-10 and ICPC, and SNOMED CT concepts. By combining Dutch concepts from UMLS and SNOMED CT, a table of primary names, synonyms and abbreviations commonly used in Dutch medical language is generated: ~574,000 names in ~254,000 concepts (Fall 2022 releases of UMLS and SNOMED CT). Adding English drug names results in ~754,000 names in ~368,000 concepts. The resulting concept table can be used for named entity recognition and linking, such as [MedCAT](https://github.com/CogStack/MedCAT), to identify entities in Dutch medical text.
 
-A workflow for creating a concept table based solely on Dutch SNOMED CT  is also present in this repository.
+A workflow for creating a concept table based solely on Dutch SNOMED CT is also present in this repository.
 
 Data and usage licenses should be acquired from [UMLS Terminology Services](https://uts.nlm.nih.gov/uts/) and [SNOMED](https://mlds.ihtsdotools.org/).
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See https://github.com/CogStack/MedCAT/tree/master/examples for a detailed expla
 I'm not sure whether the UMLS license allows for publishing snippets of UMLS data for demonstration purposes, so this repository uses mock data in the examples.
 
 ### 1. Obtain license and download complete UMLS
-To download UMLS, visit the [NIH National Library of Medicine website](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html). You'll have to apply for a license before you can download the files. In the following description I downloaded the 2021AA release `umls-2021AA-full.zip`.
+To download UMLS, visit the [NIH National Library of Medicine website](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html). You'll have to apply for a license before you can download the files. In the following description I downloaded the 2022AB release `umls-2022AB-full.zip`.
 
 ### 2. Decompress and install MetamorphoSys
 Recommended folder structure for data (these folders are added to `.gitignore`):
@@ -50,43 +50,35 @@ dutch-umls
 └───04_ConceptDB
 ```
 
-After decompressing the `*-full.zip` file, go into the folder (`2021AA-full` for me) and decompress `mmsys.zip`. Afterwards, move the files in the new `mmsys` folder one level up, so they are in `2021AA-full`. Next, run MetamorphoSys (`./run_mac.sh` on macOS)
+After decompressing the `*-full.zip` file, go into the folder (`2022AB-full` for me) and decompress `mmsys.zip`. Afterwards, move the files in the new `mmsys` folder one level up, so they are in `2022AB-full`. Next, run MetamorphoSys (`./run_mac.sh` on macOS)
 
 ### 3. Select UMLS concepts for Dutch medical language using MetamorphoSys
 MetamorphoSys is used to install a subset of UMLS. During the installation process it is possible to select multiple sources, and thereby to craft a specific subset for your use case. In our case, our primary goal is to select the Dutch terms and we add some English sources for concept categories for common used English names in Dutch (such as drug names).
 
 - Select `Install UMLS`.
-- Select destination directory.
+- Select destination directory, for example `./02_ExtractSubset/2022AB/
 - Keep `Metathesaurus` checked, and uncheck `Semantic Network` and `SPECIALIST Lexicon & Lexical Tools`. Select `OK`.
 - Select `New Configuration...`, click `Accept` and click `Ok`. The `Default Subset` does not matter because we are making our own subset in the next step.
 - In the `Output Options` tab, select `MySQL 5.6` under `Select database`.
-- In the `Source List` tab, Select `Select sources to INCLUDE in subset`. Sort the sources on the language column and at least select the 7 Dutch sources. To select multiple sources, hold the CMD key on macOS. In the popup window that will ask if you also want to include related sources, click `Cancel`. Statistics for Dutch sources in `UMLS 2021AA-full`:
+- In the `Source List` tab, Select `Select sources to INCLUDE in subset`. Sort the sources on the language column and at least select the 7 Dutch sources. To select multiple sources, hold the CMD key on macOS. In the popup window that will ask if you also want to include related sources, click `Cancel`. Statistics for Dutch sources in `UMLS 2022AB-full`:
 
-| Source name | Source ID | Last updated | Concepts |
+| Source name | Source ID |
 |---|---|---|---|
-| ICD10, Dutch Translation, 200403 | ICD10DUT_200403 | 2005 | 10697 |
-| ICPC2-ICD10 Thesaurus, Dutch Translation | ICPC2ICD10DUT | 2005 | 35466 |
-| ICPC2E Dutch | ICPC2EDUT_200203 | 2005 | 685 |
-| ICPC, Dutch Translation, 1993 | ICPCDUT_1993 | 1999 | 722 |
-| LOINC Linguistic Variant - Dutch, Netherlands | LNC-NL-NL_267 | 2020 (twice a year) | 53938 |
-| MedDRA Dutch | MDRDUT22_1 | 2020 (twice a year) | 56914 |
-| MeSH Dutch | MSHDUT2005 | 2005 | 20615 |
+| ICD10, Dutch Translation, 200403 | ICD10DUT_200403 |
+| ICPC2-ICD10 Thesaurus, Dutch Translation | ICPC2ICD10DUT_200412 |
+| ICPC2E Dutch | ICPC2EDUT_200203 |
+| ICPC, Dutch Translation, 1993 | ICPCDUT_1993 |
+| LOINC Linguistic Variant - Dutch, Netherlands | LNC-NL-NL_273 |
+| MedDRA Dutch | MDRDUT25_0 |
+| MeSH Dutch | MSHDUT2005 |
 
 - For drug names some common synonyms are missing in these vocabularies. Therefore I also selected:  
-  - `ATC_2021_21_03_01`
-  - `DRUGBANK5.0_2021_01_29`
-  - `RXNORM_20AA_210301F`.
+  - `ATC_2022_22_09_06`
+  - `DRUGBANK5.0_2022_08_01`
+  - `RXNORM_20AA_220906F`.
 - Also, it's useful to include other categories useful for remapping source ontologies (such as Dutch SNOMED -> English SNOMED -> UMLS). The selection of Dutch and English drug names is done in a Jupyter Notebook in a later step, so it's okay to include some more non-Dutch sources. In our use-case, we added the following concepts:
-  - `SNOMEDCT_US_2021_03_01` (required for adding Dutch SNOMED terms in a later step)
-  - `DSM-5_2015`
-  - `GO2020_05_02`
-  - `GS_2021_02_09`
-  - `HGNC2020_05`
+  - `SNOMEDCT_US_2022_09_01` (required for adding Dutch SNOMED terms in a later step)
   - `HPO2020_10_12`
-  - `ICD10AM_2000`
-  - `ICD10CM_2021`
-  - `ICD10PCS_2021`
-  - `MDR23_1`
   - `MTH`
 - In the `Suppressibility` tab, make sure the obsolete terms are suppressed (`LO` for LOINC, `OL` for MedDRA; see https://www.nlm.nih.gov/research/umls/knowledge_sources/metathesaurus/release/abbreviations.html). In my configuration, I unsuppressed the "Abbreviation in any source vocabulary" (`AB`) concepts from MedDRA.
 - On macOS, in the top bar, select `Advanced Suppressibility Options` and check all checkboxes. This makes sure the suppressed terms are excluded from the subset.
@@ -103,12 +95,12 @@ cp .env-example .env
 # Set local file paths & MySQL root password in .env
 
 # Set MySQL loading config settings 
-vim <local_umls_subset_dir>/2021AA/META/populate_mysql_db.sh
+vim ./02_ExtractSubset/2022AB/META/populate_mysql_db.sh
 
-# MYSQL_HOME=/usr
-# user=root
-# password=<secret_password>
-# db_name=umls
+MYSQL_HOME=/usr
+user=root
+password=${MYSQL_ROOT_PASSWORD}
+db_name=${MYSQL_DATABASE}
 
 # Start MySQL container in Docker
 docker-compose up -d
@@ -117,7 +109,7 @@ docker-compose up -d
 docker exec -it umls bash
 
 # Execute mysql loading script
-cd /src_files/2021AA/META/
+cd /src_files/2022AB/META/
 bash populate_mysql_db.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See https://github.com/CogStack/MedCAT/tree/master/examples for a detailed expla
 
 I'm not sure whether the UMLS license allows for publishing snippets of UMLS data for demonstration purposes, so this repository uses mock data in the examples.
 
-### 1. Obtain license and download complete UMLS and 
+### 1. Obtain license and download complete UMLS 
 To download UMLS, visit the [NIH National Library of Medicine website](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html). You'll have to apply for a license before you can download the files on https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html. In the following description I downloaded `Full Release (umls-2022AB-full.zip)`. The advantage over `UMLS Metathesaurus Full Subset` is that the Full Release includes MetamorphoSys which makes it possible to create a subset of UMLS prior loading the data in a SQL database. This significantly decreases the required disk space and processing time.
 
 ### 2. Decompress and install MetamorphoSys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   umls:
     container_name: umls
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci
     image: mysql:5.7
     restart: always
     ports:

--- a/dutch-snomed_to_concept-table.ipynb
+++ b/dutch-snomed_to_concept-table.ipynb
@@ -3,83 +3,90 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "compound-seller",
+   "id": "5cca26e4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
     "import json\n",
+    "import os\n",
     "import re\n",
-    "import os"
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Input\n",
+    "nl_terms = Path('01_Download/SnomedCT_ManagedServiceNL_PRODUCTION_NL1000146_20220930T120000Z/Snapshot/Terminology/sct2_Description_Snapshot-nl_NL1000146_20220930.txt')\n",
+    "\n",
+    "# Output\n",
+    "output_file_name = '04_ConceptDB/snomedct-dutch_v1.3.csv'\n",
+    "output_file_name_unfiltered = '04_ConceptDB/snomedct-dutch_v1.3-unfiltered.csv'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "needed-prospect",
+   "id": "f2c0de3a",
    "metadata": {},
    "source": [
-    "\n",
     "## Sources files\n",
-    "\n",
-    "To count total number of records in the SNOMED files, use `wc -l` and substract 1 for header.\n",
-    "```bash\n",
-    "wc -l SnomedCT_Netherlands_*_PRODUCTION_20210930T120000Z/Snapshot/Terminology/sct2_Description_*.txt\n",
-    "```\n",
-    "\n",
-    "To count number of NL records in the SNOMED files, use `grep` and `wc -l`.\n",
-    "```bash\n",
-    "grep \"\\tnl\\t\" SnomedCT_Netherlands_EditionRelease_PRODUCTION_20210930T120000Z/Snapshot/Terminology/sct2_Description_Snapshot_NL_20210930.txt | wc -l\n",
-    "```\n",
     "\n",
     "### SNOMED September 2020 release\n",
     "| Edition | Total names | NL names | Description |\n",
     "| - | - | - | - |\n",
     "| Edition | 2263140 | 736619 | Include international SNOMED |\n",
     "| Extension | 770016 | 736619 | Some terms are only in English |\n",
-    "| Patient Friendly | 1437 | 1437 | Small but potentially useful list of synonyms |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b1da9ee8",
-   "metadata": {},
-   "source": [
-    "### SNOMED March 2021 release\n",
+    "| Patient Friendly | 1437 | 1437 | Small but potentially useful list of synonyms |\n",
     "\n",
+    "### SNOMED March 2021 release\n",
     "| Edition | Total names | NL names | Description |\n",
     "| - | - | - | - |\n",
     "| Edition | 2422738 | 880806 | Include international SNOMED |\n",
     "| Extension | 916553 | 880806 | Some terms are only in English |\n",
-    "| Patient Friendly | 2004 | 2004 | Small but potentially useful list of synonyms |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9c9cc897",
-   "metadata": {},
-   "source": [
+    "| Patient Friendly | 2004 | 2004 | Small but potentially useful list of synonyms |\n",
+    "\n",
     "### SNOMED September 2021 release\n",
     "\n",
     "| Edition | Total names | NL names | Description |\n",
     "| - | - | - | - |\n",
     "| Edition | 2469845 | 910228 | Include international SNOMED |\n",
     "| Extension | 948571 | 910228 | Some terms are only in English |\n",
-    "| Patient Friendly | 2385 | 2385 | Small but potentially useful list of synonyms |"
+    "| Patient Friendly | 2385 | 2385 | Small but potentially useful list of synonyms |\n",
+    "\n",
+    "\n",
+    "### SNOMED September 2022 release\n",
+    "To count total number of records in the SNOMED files, use `wc -l` and substract 1 for header.\n",
+    "```bash\n",
+    "wc -l SnomedCT_*/Snapshot/Terminology/sct2_Description_*.txt\n",
+    "```\n",
+    "\n",
+    "| File | Language | NL names |\n",
+    "| - | - | - |\n",
+    "| sct2_Description_Snapshot-en_NL1000146_20220930.txt | English | 1611131 |\n",
+    "| sct2_Description_Snapshot-nl_NL1000146_20220930.txt | Dutch | 945292 |\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1667031d",
+   "id": "aea192d7",
    "metadata": {},
    "source": [
-    "The \"Edition\" contains many English names, so for our Dutch concept table we will use the \"Extention\" and \"Patient Friendly\" terms."
+    "### Description type\n",
+    "The SNOMED description table contains 3 types of records:\n",
+    "\n",
+    "|Type id|Term|\n",
+    "|-|-|\n",
+    "|900000000000003001|Fully specified name (FSN)|\n",
+    "|900000000000013009|Synonym|\n",
+    "|900000000000550004|Definition|\n",
+    "\n",
+    "The the purpose of creating a list of names for entity recognation, terms must be:\n",
+    "- FSN or Synonym\n",
+    "- Active"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tight-cooking",
+   "id": "d555b3a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,75 +99,29 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vietnamese-dining",
+   "id": "0ae1847d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "snomed_dir = '/Users/stan3/Data/snomed'\n",
-    "release_date = '20210930'\n",
-    "nl_ed_term = os.path.join(snomed_dir, f'SnomedCT_Netherlands_EditionRelease_PRODUCTION_{release_date}T120000Z/Snapshot/Terminology/sct2_Description_Snapshot_NL_{release_date}.txt')\n",
-    "nl_ex_term = os.path.join(snomed_dir, f'SnomedCT_Netherlands_ExtensionRelease_PRODUCTION_{release_date}T120000Z/Snapshot/Terminology/sct2_Description_Snapshot_NL_{release_date}.txt')\n",
-    "nl_pf_term = os.path.join(snomed_dir, f'SnomedCT_Netherlands_PatientFriendlyExtensionRelease_PRODUCTION_{release_date}T120000Z/Snapshot/Terminology/sct2_Description_Snapshot_NL-PatientFriendly_{release_date}.txt')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dependent-variable",
-   "metadata": {},
-   "source": [
-    "### Description type\n",
-    "The SNOMED description table contains 3 types:\n",
-    "\n",
-    "|Type id|Term|\n",
-    "|-|-|\n",
-    "|900000000000003001|Fully specified name (FSN)|\n",
-    "|900000000000013009|Synonym|\n",
-    "|900000000000550004|Definition|\n",
-    "\n",
-    "The the purpose of creating a list of names for entity recognation, terms must be:\n",
-    "- FSN or Synonym\n",
-    "- Active\n",
-    "- Dutch"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "remarkable-trader",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Select active terms from Extention release\n",
-    "df_ex = parse_file(nl_ex_term)\n",
-    "df_ex_active = df_ex[(df_ex.languageCode == 'nl') & (df_ex.active == '1')].copy()\n",
-    "df_ex_inactive = df_ex[(df_ex.languageCode == 'nl') & (df_ex.active != '1')]\n",
-    "print(f'Extention Release Active: {df_ex_active.shape[0]}')\n",
-    "print(f'Extention Release Inactive: {df_ex_inactive.shape[0]}\\n')\n",
+    "# Select active terms\n",
+    "df_terms = parse_file(nl_terms)\n",
+    "df_terms_active = df_terms.loc[df_terms.active == '1'].copy()\n",
+    "df_terms_inactive = df_terms.loc[df_terms.active != '1'].copy()\n",
+    "print(f'Active terms: {df_terms_active.shape[0]}')\n",
+    "print(f'Inactive terms: {df_terms_inactive.shape[0]}\\n')\n",
     "\n",
     "# Extract fully specified names\n",
-    "df_fsn = df_ex_active[(df_ex_active.typeId == '900000000000003001')]\n",
-    "print(f'Extention Release Active FSN: {df_fsn.shape[0]}')\n",
+    "df_fsn = df_terms_active[(df_terms_active.typeId == '900000000000003001')].copy()\n",
+    "print(f'Active FSN: {df_fsn.shape[0]}')\n",
     "\n",
     "# Extract synonyms\n",
-    "df_ex_synonyms = df_ex_active[(df_ex_active.typeId == '900000000000013009')].copy()\n",
-    "print(f'Extention Release Active Synonyms: {df_ex_synonyms.shape[0]}\\n')\n",
-    "\n",
-    "# Select active terms from patient friendly extention release\n",
-    "df_pf = parse_file(nl_pf_term)\n",
-    "df_pf_active = df_pf[(df_pf.typeId == '900000000000013009') & (df_pf.active == '1')].copy()\n",
-    "df_pf_inactive = df_pf[(df_pf.typeId == '900000000000013009') & (df_pf.active == '0')]\n",
-    "print(f'Patient Friendly Extention release Active: {df_pf_active.shape[0]}')\n",
-    "print(f'Patient Friendly Extention release Inactive: {df_pf_inactive.shape[0]}\\n')\n",
-    "\n",
-    "# Merge synonyms and patient friendly terms as synonyms in our Concept table\n",
-    "df_synonyms = pd.concat([df_ex_synonyms,\n",
-    "                         df_pf_active])\n",
-    "print(f'Total synonyms: (Extention Release synonyms & Patient Friendly): {df_synonyms.shape[0]}')"
+    "df_terms_synonyms = df_terms_active[(df_terms_active.typeId == '900000000000013009')].copy()\n",
+    "print(f'Active Synonyms: {df_terms_synonyms.shape[0]}\\n')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "written-remains",
+   "id": "9f5557fb",
    "metadata": {},
    "source": [
     "### Primary concepts"
@@ -169,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "diagnostic-interview",
+   "id": "0e85c79d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nearby-spiritual",
+   "id": "49198a19",
    "metadata": {},
    "source": [
     "### Synonyms"
@@ -195,26 +156,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "joint-providence",
+   "id": "50b6d6a8",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Clean synonym table\n",
-    "df_synonym_concepts = df_synonyms.copy()\n",
-    "df_synonym_concepts = df_synonym_concepts[['conceptId', 'term', 'typeId']]\n",
-    "df_synonym_concepts.rename({'term': 'str'}, inplace=True, axis=1)\n",
+    "df_synonyms = df_terms_synonyms.copy()\n",
+    "df_synonyms = df_synonyms[['conceptId', 'term', 'typeId']]\n",
+    "df_synonyms.rename({'term': 'str'}, inplace=True, axis=1)\n",
     "\n",
     "# Add TUI to synonyms\n",
-    "df_synonym_concepts['tui'] = df_synonym_concepts.conceptId.map(cui_tui_mapping)\n",
-    "# df_synonym_concepts[df_synonym_concepts['tui'].isna()].shape\n",
+    "df_synonyms['tui'] = df_synonyms.conceptId.map(cui_tui_mapping)\n",
+    "# df_synonyms[df_synonyms['tui'].isna()].shape\n",
     "# 67 synonyms without type\n",
     "\n",
-    "df_synonym_concepts"
+    "df_synonyms.head()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "quiet-advancement",
+   "id": "f2dd5a4c",
    "metadata": {},
    "source": [
     "### Combined"
@@ -223,12 +184,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accessory-bristol",
+   "id": "c9882328",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create combined \n",
-    "df_all = pd.concat([df_primary_concepts, df_synonym_concepts]).reset_index(drop=True)\n",
+    "df_all = pd.concat([df_primary_concepts, df_synonyms]).reset_index(drop=True)\n",
     "df_all.rename({'typeId': 'tty', 'conceptId': 'cui'}, inplace=True, axis=1)\n",
     "\n",
     "# Map to MedCAT's P (Preferred term) & A values\n",
@@ -247,14 +208,29 @@
     "\n",
     "# Sort column on cui and tty\n",
     "df_all_unique['cui'] = df_all_unique['cui'].astype(int)\n",
-    "df_all_unique.sort_values(['cui', 'tty'], inplace=True)\n",
+    "df_all_unique.sort_values(['cui', 'tty'], ascending=[True, False], inplace=True)\n",
     "\n",
-    "df_all_unique.head()"
+    "df_all_unique.head(25)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7ee548a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A few rows contain NaN\n",
+    "# Easiest way to deal with it is drop them. \n",
+    "display(df_all_unique[df_all_unique.isnull().any(axis=1)].head())\n",
+    "print(len(df_all_unique))\n",
+    "df_all_unique.dropna(inplace=True)\n",
+    "print(len(df_all_unique))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dimensional-judges",
+   "id": "e0d328a2",
    "metadata": {},
    "source": [
     "### Examples"
@@ -263,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "diverse-republic",
+   "id": "cb3e8d6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bored-celebrity",
+   "id": "f5664211",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "imposed-nickname",
+   "id": "d8071318",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "developing-berkeley",
+   "id": "9e373b3f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "thermal-shoulder",
+   "id": "6bad4c0c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "numeric-combining",
+   "id": "d527a483",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "widespread-juvenile",
+   "id": "b4634b3c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "constant-marble",
+   "id": "72c009f5",
    "metadata": {},
    "source": [
     "## Evaluation of SNOMED types"
@@ -340,16 +316,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "logical-history",
+   "id": "faa7cba8",
    "metadata": {},
    "source": [
-    "Find which types are present, and then manually check the performance of the types by looking at a set of cardiology letters."
+    "To select the types relevant for named entity linking, we assessed the performance of a MedCAT model on a set of example documents using the unfiltered SNOMED terms. We noticed some types are not useful for our general purpose (named entity recognition), and introduce false positives and ambiguity. We exclude the less usefull types from our concept table."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "activated-metro",
+   "id": "19af7c02",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,44 +333,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "motivated-speaking",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Total number of concepts\n",
-    "df_all_unique.shape[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "persistent-caution",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Number of primary concepts\n",
-    "df_all_unique[df_all_unique.tty == 'PN'].shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "detected-holiday",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Number of synonyms\n",
-    "df_all_unique[df_all_unique.tty == 'SY'].shape"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "crazy-belfast",
+   "id": "f435a509",
    "metadata": {},
    "source": [
-    "| tui | summary | good examples | bad examples |\n",
+    "| tui | usefullness for NER | useful examples for NER | useless examples for NER |\n",
     "| :- | :- | :- | :-|\n",
     "|aandoening |good|hypertensie, boezemfibrilleren, av-blok| |\n",
     "|monster|good|trombocyten, leukocyten,basofiele granulocyten||\n",
@@ -425,7 +368,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "backed-syntax",
+   "id": "c1b4f3ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Total number of concepts\n",
+    "df_all_unique.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3524d57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Number of primary concepts\n",
+    "df_all_unique[df_all_unique.tty == 'P'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4954e9e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Number of synonyms\n",
+    "df_all_unique[df_all_unique.tty == 'A'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9156f0a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "secure-genius",
+   "id": "4cb5bdfd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adapted-norfolk",
+   "id": "2f106994",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fabulous-latin",
+   "id": "788dfad3",
    "metadata": {},
    "source": [
     "## Output"
@@ -473,13 +449,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "median-discount",
+   "id": "776cbd5a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Save to file\n",
-    "df_all_unique.to_csv('04_ConceptDB/snomedct-dutch_v1.2-unfiltered.csv', index=False)\n",
-    "df_all_unique[df_all_unique.tui.isin(relevant_tuis)].to_csv('04_ConceptDB/snomedct-dutch_v1.2.csv', index=False)"
+    "df_all_unique.to_csv(output_file_name_unfiltered, index=False)\n",
+    "df_all_unique[df_all_unique.tui.isin(relevant_tuis)].to_csv(output_file_name, index=False)"
    ]
   }
  ],
@@ -499,7 +475,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/dutch-umls_to_concept-table.ipynb
+++ b/dutch-umls_to_concept-table.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "88668725",
+   "id": "ab651d93",
    "metadata": {},
    "source": [
     "# Dutch UMLS to concept table\n",
@@ -19,37 +19,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4d4edf2",
+   "id": "ce8b674a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set output version of the generated UMLS dutch concept table\n",
-    "UMLS_DUTCH_VERSION = 'v1.10'\n",
-    "\n",
-    "# Set input version of SNOMED to append to UMLS terms\n",
-    "SNOMED_DUTCH_VERSION = 'v1.2'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b8d2278f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sqlalchemy import create_engine\n",
-    "from dotenv import load_dotenv\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
     "import json\n",
+    "import os\n",
     "import re\n",
-    "import os"
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import display\n",
+    "from pathlib import Path\n",
+    "from sqlalchemy import create_engine\n",
+    "\n",
+    "pd.set_option('max_colwidth', 400)\n",
+    "\n",
+    "# Set output version of the generated UMLS dutch concept table\n",
+    "UMLS_DUTCH_VERSION = 'v1.11-beta'\n",
+    "\n",
+    "# Set version of SNOMED to append to UMLS terms\n",
+    "snomed_dutch_file = Path('04_ConceptDB') / 'snomedct-dutch_v1.3.csv'"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d585074",
+   "id": "8f3587d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,9 +63,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0e627875",
+   "metadata": {},
+   "source": [
+    "## Retrieve medical concepts"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "917a6d76",
+   "id": "f6b5c52f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +87,95 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dac58ef",
+   "id": "166d44df",
+   "metadata": {},
+   "source": [
+    "## Manual corrections\n",
+    "Some manual corrections. Easiest to do this as close to the source as possible, so they are processed downstream correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "498f8bde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Correct Respiratory Failure\n",
+    "# Respiratory Insufficiency / C0035229 / 409623005 / https://uts.nlm.nih.gov/uts/umls/concept/C0035229\n",
+    "# Respiratory Failure / C1145670 / 409622000 / https://uts.nlm.nih.gov/uts/umls/concept/C1145670\n",
+    "display(dutch_umls_original.loc[dutch_umls_original.cui == 'C0035229'])\n",
+    "display(dutch_umls_original.loc[dutch_umls_original.cui == 'C1145670'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27e9cab5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dutch_umls_original.loc[dutch_umls_original.str == 'Respiratoire insufficiëntie, niet gespecificeerd', 'cui'] = 'C0035229'\n",
+    "dutch_umls_original.loc[dutch_umls_original.str == 'Ademhalingsinsufficiëntie', 'cui'] = 'C0035229'\n",
+    "display(dutch_umls_original.loc[dutch_umls_original.cui == 'C0035229'])\n",
+    "display(dutch_umls_original.loc[dutch_umls_original.cui == 'C1145670'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec63d914",
+   "metadata": {},
+   "source": [
+    "## Filter on terminology and type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fca77c25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dutch_umls_original.sab.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f74cfc08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assess terms per terminology\n",
+    "dutch_umls_original.loc[dutch_umls_original['sab'].isin(['LNC-NL-NL', 'ICPC2ICD10DUT'])].sample(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acb9a096",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'LNC-NL-NL' and 'ICPC2ICD10DUT' names are not usefull for named entities linking, so we exclude these\n",
+    "dutch_umls_sab_filtered = dutch_umls_original.loc[~dutch_umls_original['sab'].isin(['LNC-NL-NL', 'ICPC2ICD10DUT'])].copy()\n",
+    "dutch_umls_sab_filtered.sample(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b1d2819",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assess terms per type\n",
+    "dutch_umls_sab_filtered.loc[dutch_umls_sab_filtered['tty']=='HT'].sample(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f766e50",
    "metadata": {},
    "source": [
     "## Term type in source\n",
@@ -93,177 +185,218 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e075074",
+   "id": "270be30d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "dutch_umls_original.tty.value_counts()"
+    "dutch_umls_sab_filtered.tty.value_counts()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "683ba8d5",
+   "id": "075b53fa",
    "metadata": {},
    "source": [
-    "| TTY  | Description | Count | Example | Reference|\n",
-    "| - | - | - | - | - |\n",
-    "| PT | Designated preferred name| 111766 | harthypertrofie, Pancoast-syndroom ||\n",
-    "| LLT | Lower Level Term | 71603 | heupkombreuk, buikkramp| |\n",
-    "| LN | LOINC official fully specified name | 52313 | fencyclidine:massa/massa:moment:haar:kwantitatief | |\n",
-    "| MH | Main heading | 28657 | Dehydratie, Astma | |\n",
-    "| SY | Designated synonym | 11863 | Spanningshoofdpijn, Ziekte van Hodgkin | |\n",
-    "| OL | Non-current Lower Level Term| 9291 | acquired immunodeficiency syndrome, ankylose van gewricht, meerdere plaatsen | https://meddra.org/sites/default/files/page/documents_insert/meddra_-_terminologies_coding.pdf |\n",
-    "| HT | Hierarchical term | 3295 | calciummetabolismestoornissen, oculaire hemorragische aandoeningen\t | |\n",
-    "| LO | Obsolete official fully specified name | 1696| promyelocyten/100 leukocyten:getalsfractie:mom...\t| |\n",
-    "| HG | High Level Group Term |  337| complicaties geassocieerd met medisch hulpmiddel, zuur-basestoornissen | |\n",
-    "| SMQ| Standardised MedDRA Query |  225| Leveraandoeningen (SMQ) , Tumormarkers (SMQ) | |\n",
-    "| CP | ICPC component process (in original form) |   38| Ander bloedonderzoek, Medicatie/recept/injectie | |\n",
-    "| OS | System-organ class |   27| Bloed- en lymfestelselaandoeningen, Infecties en parasitaire aandoeningen | |\n",
-    "| AB | Abbreviation in any source vocabulary |   27| Infec, Neopl, Ear, Endo | |"
+    "| TTY  | Description | Count | Example |\n",
+    "| - | - | - | - |\n",
+    "| LLT | Lower Level Term | 71603 | heupkombreuk, buikkramp|\n",
+    "| PT | Designated preferred name| 35746 | harthypertrofie, Pancoast-syndroom |\n",
+    "| MH | Main heading | 28618 | Dehydratie, Astma |\n",
+    "| SY | Designated synonym | 11859 | Spanningshoofdpijn, Ziekte van Hodgkin |\n",
+    "| HT | Hierarchical term | 3296 | calciummetabolismestoornissen, oculaire hemorragische aandoeningen |\n",
+    "| HG | High Level Group Term | 337 | complicaties geassocieerd met medisch hulpmiddel, zuur-basestoornissen |\n",
+    "| SMQ| Standardised MedDRA Query | 228| Leveraandoeningen (SMQ) , Tumormarkers (SMQ) |\n",
+    "| CP | ICPC component process (in original form) | 38 | Ander bloedonderzoek, Medicatie/recept/injectie |\n",
+    "| AB | Abbreviation in any source vocabulary | 27 | Infec, Neopl, Ear, Endo |\n",
+    "| OS | System-organ class | 27 | Bloed- en lymfestelselaandoeningen, Infecties en parasitaire aandoeningen |"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4764c04",
+   "id": "1088acde",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Select a set of TTYs that seem most relevant for entity linking\n",
+    "# Select a set of TTYs that seem most relevant for named entity recognition\n",
     "tty_selection = ['PT', 'LLT', 'MH', 'SY']\n",
-    "dutch_umls = dutch_umls_original[dutch_umls_original.tty.isin(tty_selection)].copy()\n",
+    "dutch_umls_tty_filtered = dutch_umls_sab_filtered.loc[dutch_umls_sab_filtered.tty.isin(tty_selection)].copy()\n",
     "\n",
     "# Keep only relevant columns\n",
-    "dutch_umls = dutch_umls[['cui', 'str', 'tty', 'sab']]"
+    "dutch_umls_tty_filtered = dutch_umls_tty_filtered[['cui', 'str', 'tty', 'sab']]\n",
+    "dutch_umls_tty_filtered.sample(5)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "41a0488b",
+   "id": "1faf74bb",
    "metadata": {},
    "source": [
-    "## Preferred names\n",
-    "Most, if not all, of UMLS concepts have a preferred name in English. For other languages,\n",
+    "## Preferred/pretty/primary names\n",
+    "For MedCAT, and other named entity linking methods, it's useful to designate a single name as the preferred name, also sometimes called primary name or pretty name. This name can be presented to the end-user in webapplications, and should therefore be the most descriptive and commonly used name. All other names (synonyms, abreviations and common mispellings) will then be considered synonyms. MedCAT used 'P' as the value for preferred name, and all other names should have the value 'A' (see https://github.com/CogStack/MedCAT/blob/master/examples/README.md).\n",
+    "\n",
+    "Most, if not all, of UMLS concepts have a preferred in English. For other languages,\n",
     "it can be difficult to select a preferred name, because each source vocabulary has one or\n",
-    "multiple preferred names for a concepts. For example, ICPC2ICD10DUT only contains preferred name-type values.\n",
+    "multiple preferred names for a concepts.\n",
     "\n",
     "It's not possible to keep the English UMLS preferred names, because MedCAT would add those names to the concept table for entity linking. Perhaps future functionality can be added for MedCAT to prevent taking these preferred names into account during entity linking.\n",
     "\n",
     "### Solution 1: Use UMLS source vocabularies preferred names\n",
-    "For a rough but effective solution to get decent preferred names for the Dutch terms, change the terms that have the value \"Designated preferred name\" (PT) for the \"Term Type in Source\" (TTY) to MedCAT's preferred name value (P), and all others can be saved as (A). See https://github.com/CogStack/MedCAT/blob/master/examples/README.md"
+    "For a rough but effective solution to get decent preferred names for the Dutch terms, change the terms that have the value \"Designated preferred name\" (PT) for the \"Term Type in Source\" (TTY) to MedCAT's preferred name value (P), and all others can be saved as (A). This leads to many concepts having multiple preferred names."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3925069",
+   "id": "32542b2b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# dutch_umls.tty.replace({'PT': 'P',\n",
-    "#                                   'LLT': 'A',\n",
-    "#                                   'MH': 'A',\n",
-    "#                                   'SY': 'A'}, inplace=True)"
+    "# dutch_umls_tty_filtered.tty.replace({'PT': 'P',\n",
+    "#                                      'LLT': 'A',\n",
+    "#                                      'MH': 'A',\n",
+    "#                                      'SY': 'A'}, inplace=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7f0d634f",
+   "id": "6597fb19",
    "metadata": {},
    "source": [
     "### Solution 2: Use preferred names from Dutch SNOMED\n",
-    "In previous experiments we have shown that the Dutch vocabularies from UMLS and Dutch SNOMED complement each other. SNOMED however, does provide most of the names, and contains excellent primary names. So we could use the preferred names from Dutch SNOMED, and for the terms not in that vocabulary, let MedCAT pick a random one."
+    "In previous experiments we have shown that the Dutch vocabularies from UMLS and Dutch SNOMED complement each other. SNOMED provides most of the names, and contains excellent primary names. So we could use the preferred names from Dutch SNOMED, and for the terms not in that vocabulary, let MedCAT pick a random one."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfc16ac8",
+   "id": "c2e5db1a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Drop tty column, put it back in just before merging with SNOMED\n",
-    "dutch_umls.drop(['tty'], axis=1, inplace=True)\n",
-    "dutch_umls.head()"
+    "dutch_umls_tty_filtered.drop(['tty'], axis=1, inplace=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16a07c8d",
+   "id": "97bc7f1e",
    "metadata": {},
    "source": [
-    "## Clean values"
+    "## Clean values\n",
+    "ICD10DUT and MDRDUT contain names that are more definitions than then how they would be found in text. For example, \"colonkanker NAO\" (see https://alt.meddra.org/files_acrobat/intguide_25_0_Dutch.pdf) and \"Aandoening van ooglid, niet gespecificeerd\". Names are more useful for named entity recongition when the descriptive part is removed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab933e50",
+   "id": "242a3b8e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "dutch_umls[dutch_umls.cui == 'C0000833']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "64daba6b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Remove \"NAO\" (\"Niet Anders Omschreven\"), which is relevant for the source terminlogy but not for entity linking.\n",
-    "# See https://meddra.org/sites/default/files/guidance/file/intguide_15_0_dutch.pdf\n",
-    "dutch_umls.str = dutch_umls.str.replace({' NAO': '', ' \\(NAO\\)': '', ' nao': ''}, regex=True)\n",
-    "dutch_umls[dutch_umls.cui == 'C0000833']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7021b6a0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def convert_title_to_lowercase(name):\n",
-    "    if name.split(' ')[0].istitle():\n",
-    "        return name.lower()\n",
-    "    else:\n",
-    "        return name\n",
+    "dutch_umls_clean = dutch_umls_tty_filtered.copy()\n",
     "\n",
-    "# Many ontologies start all names with an uppercase and consider it a title. \n",
-    "# SNOMEDCT does not do this, so to prevent duplication, convert all title-cased names to lowercase.\n",
-    "# Converting all names to lowercase could lead to issues for names that are in all uppercase, such as ALS.\n",
-    "dutch_umls['str'] = dutch_umls['str'].apply(convert_title_to_lowercase)\n",
-    "dutch_umls[dutch_umls.cui == 'C0000833']"
+    "# Remove ' nao' and ' NAO'\n",
+    "print(f\"Number of terms containing ' NAO': {len(dutch_umls_clean.loc[dutch_umls_clean['str'].str.contains(' NAO')])}\")\n",
+    "print(f\"Number of terms containing ' nao': {len(dutch_umls_clean.loc[dutch_umls_clean['str'].str.contains(' nao')])}\")\n",
+    "dutch_umls_clean.str = dutch_umls_clean.str.replace({' NAO': '', ' \\(NAO\\)': '', ' nao': ''}, regex=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2bf07618",
+   "id": "ba345c03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Number of terms containing 'gespecificeerd': {len(dutch_umls_clean.loc[dutch_umls_clean['str'].str.contains('gespecificeerd')])}\")\n",
+    "\n",
+    "# Remove suffix\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd onderzoek')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerde graad')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerde oorzaak')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerde plaats')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd type')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd deel')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd gebruik')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd naar behandelperiode')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd naar betrokkenheid')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerde toestand')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet-gespecificeerd naar oorzaak')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix(', niet gespecificeerd')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removesuffix('; Niet gespecificeerd')\n",
+    "\n",
+    "# Remove prefix\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removeprefix('niet-gespecificeerde ')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removeprefix('niet-gespecificeerd ')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removeprefix('Niet gespecificeerd ')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].str.removeprefix('Niet gespecificeerde ')\n",
+    "\n",
+    "print(f\"Number of terms containing 'gespecificeerd': {len(dutch_umls_clean.loc[dutch_umls_clean['str'].str.contains('gespecificeerd')])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a79e8dab",
+   "metadata": {},
+   "source": [
+    "There are many occurences of 'gespecificeerd' in names left, but these are more difficult to clean. For now, these are likely not causing any issues (but probably also not adding much) so we'll keep them in our table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b47d0331",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_title_to_lowercase(old_name, split_char=' '):\n",
+    "    \"\"\"\n",
+    "    Many ontologies start all names with an uppercase.\n",
+    "    SNOMED does not do this, except for names such as \"ziekte van Parkinson\", so to prevent duplication, convert all title-cased names to lowercase.\n",
+    "    Converting everything to lowercase could lead to issues for abbreviations that are in all uppercase, such as ALS.\n",
+    "    Therefore only convert names in 'title' format to lowercase.\n",
+    "        \"\"\"\n",
+    "    new_name = []\n",
+    "    for part in old_name.split(split_char):\n",
+    "        if part.istitle():\n",
+    "            new_name.append(part.lower())\n",
+    "        else:\n",
+    "            new_name.append(part)\n",
+    "            \n",
+    "    return split_char.join(new_name)\n",
+    "\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].apply(convert_title_to_lowercase, split_char=' ')\n",
+    "dutch_umls_clean['str'] = dutch_umls_clean['str'].apply(convert_title_to_lowercase, split_char='-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "925fcf68",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Drop duplicates\n",
-    "print(f'Records before dropping duplicates: {dutch_umls.shape[0]}')\n",
-    "dutch_umls = dutch_umls.drop_duplicates(subset=['cui', 'str', 'sab'], keep='first').reset_index(drop=True)\n",
-    "dutch_umls[dutch_umls.cui == 'C0000833']"
+    "print(f'Records before dropping duplicates: {dutch_umls_clean.shape[0]}')\n",
+    "dutch_umls_clean = dutch_umls_clean.drop_duplicates(subset=['cui', 'str', 'sab'], keep='first').reset_index(drop=True)\n",
+    "print(f'Records before dropping duplicates: {dutch_umls_clean.shape[0]}')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7666af4",
+   "id": "70c71d04",
    "metadata": {},
    "outputs": [],
    "source": [
-    "dutch_umls[dutch_umls.cui == 'C0002736']"
+    "dutch_umls_clean[dutch_umls_clean.cui == 'C0002736']"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "05a75a11",
+   "id": "3cb632f1",
    "metadata": {},
    "source": [
     "## Merge rows from different vocabularies"
@@ -272,43 +405,45 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e3033df",
+   "id": "b0243660",
    "metadata": {},
    "outputs": [],
    "source": [
+    "dutch_umls = dutch_umls_clean.copy()\n",
+    "\n",
     "# Merge SAB into single row\n",
     "print(f'Records before merging rows: {dutch_umls.shape[0]}')\n",
     "dutch_umls = dutch_umls.groupby(['cui','str'])['sab'].apply('|'.join).reset_index()\n",
     "print(f'Records after merging rows: {dutch_umls.shape[0]}')\n",
-    "dutch_umls[dutch_umls.cui == 'C0000833']"
+    "dutch_umls[dutch_umls.cui == 'C0002736']"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce555c75",
+   "id": "993b1531",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Add tty column with value 'A' to set these names as synonyms \n",
     "dutch_umls['tty'] = 'A'\n",
-    "dutch_umls.head(20)"
+    "dutch_umls.head()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1bfbf387",
+   "id": "986283d0",
    "metadata": {},
    "source": [
     "# Add Dutch names from SNOMED\n",
-    "UMLS does not contain the Dutch SNOMEDCT, but it does contain the English SNOMEDCT_US. So through the English SNOMED concepts, we can map the Dutch SNOMED names to UMLS.\n",
+    "UMLS does not contain the Dutch SNOMEDCT, but it does contain the English SNOMEDCT. So through the English SNOMED concepts, we can map the Dutch SNOMED names to UMLS.\n",
     "\n",
     "Dutch SNOMED names with SNOMED ID **->** Get English SNOMED ID to UMLS ID mapping **->** Map Dutch SNOMED names with SNOMED ID to UMLS ID"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "057b07cf",
+   "id": "5169a5c2",
    "metadata": {},
    "source": [
     "### Load SNOMED US"
@@ -317,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd9ef671",
+   "id": "2bb1d0b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -330,7 +465,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c77106df",
+   "id": "3c7b0218",
    "metadata": {},
    "source": [
     "### Load SNOMED NL\n",
@@ -340,18 +475,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38f4b1bf",
+   "id": "c4814eb6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "snomed_dutch = pd.read_csv(f'04_ConceptDB/snomedct-dutch_{SNOMED_DUTCH_VERSION}.csv', dtype=str)\n",
+    "snomed_dutch = pd.read_csv(snomed_dutch_file, dtype='str')\n",
     "snomed_dutch.head()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d98ea3c2",
+   "id": "1c4e4573",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +495,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2a8387b",
+   "id": "14785a8a",
    "metadata": {},
    "source": [
     "## Find ambiguous mapping"
@@ -368,28 +503,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4544a87",
+   "id": "3450fbb5",
    "metadata": {},
    "source": [
-    "First find which SNOMED concepts can map to UMLS concepts. SNOMED concepts could map to multiple UMLS concepts."
+    "First find which SNOMED concepts can map to UMLS concepts. SNOMED concepts can map to multiple UMLS concepts."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c009195",
+   "id": "dc4bb757",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create SNOMED - UMLS mapping\n",
     "snomed_to_umls_mapping = snomed_us.groupby('scui')['cui'].apply(list).to_dict()\n",
-    "print(f'Number of SNOMED US IDs that map to at least 1 CUI: {len(snomed_to_umls_mapping)}')"
+    "print(f'Number of SNOMED concepts that map to at least 1 UMLS concept: {len(snomed_to_umls_mapping)}')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "795a374e",
+   "id": "ec25f572",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,30 +536,31 @@
     "        unambiguous_mapping_ids.add(snomed_id)\n",
     "    else:\n",
     "        ambiguous_mapping_ids.add(snomed_id)\n",
-    "print(f'Number of SNOMED IDs that map to only 1 CUI: {len(unambiguous_mapping_ids)}')\n",
-    "print(f'Number of SNOMED IDs that map to multiple CUIs: {len(ambiguous_mapping_ids)}')"
+    "print(f'Number of SNOMED concepts that map to only 1 concept: {len(unambiguous_mapping_ids)}')\n",
+    "print(f'Number of SNOMED concepts that map to multiple concepts: {len(ambiguous_mapping_ids)}')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0836f0fa",
+   "id": "e36cf048",
    "metadata": {},
    "source": [
-    "So 2073 SNOMED concepts map to multiple UMLS concepts. If we would add the Dutch names from SNOMED, we would have to add them to all UMLS concepts. This will introduce ambiguity, which will lead to problems in our downstream named entity linking methods. Therefor we don't add names for these ambiguously mapping SNOMED concepts."
+    "So 2073 SNOMED concepts map to multiple UMLS concepts. If the Dutch names from these concepts are added to the UMLS concept table, it will introduce ambiguity, which could lead to problems in our downstream named entity linking methods. Therefore, for now, this method does not add names for these ambiguously mapping SNOMED concepts."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23212fd0",
+   "id": "0cc6d14a",
    "metadata": {},
    "source": [
-    "## Example of ambiguous mapping"
+    "## Example of ambiguous mapping\n",
+    "This section illustrates the ambiguous mapping problem"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "becae652",
+   "id": "b5f6be88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "594a5f1c",
+   "id": "d55263e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "897223cc",
+   "id": "8a0039a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ca6e345",
+   "id": "e326ff18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,20 +605,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b64509f",
+   "id": "74cd0d86",
    "metadata": {},
    "source": [
-    "So SNOMED US has four names for 216004. Three of these names map to C1704268 and one maps to C0151836. In SNOMED NL, there is only one name for this concept. We could map this name to both concepts, to a specific one, or ignore it.\n",
+    "So SNOMED US has four names for 216004. Three of these names map to C1704268 and one maps to C0151836. In SNOMED NL, there is only one name for this concept. In our current UMLS table, we have 2 names for each UMLS concept. We could map the SNOMED name to both concepts (1), to a specific one (2), or ignore it (3):\n",
     "\n",
-    "- Mapping to both will cause ambiguity. It might have no effect on entity linking, as it could be solved during MedCAT's unsupervised training, depending on the synonyms and their presence in the training corpus. In this example there is only 1 Dutch SNOMED term, but when there are multiple Dutch SNOMED terms, adding all to both terms, will lead to many duplicates.\n",
-    "- Mapping to a single one is the best option for a single example, but this is time consuming, not within the scope and responsibility of this project and can be quite difficult. There are about 2000 of these terms. SNOMED US names are in UMLS, so those ambiguously mapping names are are added by either the UMLS or SNOMED team.\n",
-    "- Ignoring the name is the easiest option and will not lead to potential difficult downstream interpretation. The drawback is that the name, which in this example is unique to SNOMED NL, will not be in the final Dutch UMLS table."
+    "1. Mapping to both will cause ambiguity. It could have an effect on entity linking, or it could be solved during MedCAT's disambiguation functionality based on unsupervised training, but that depends on the synonyms and their presence in the training corpus. In this example there is only 1 Dutch SNOMED term, but when there are multiple Dutch SNOMED terms, adding all to both terms will lead to many duplicates.\n",
+    "2. Mapping to a single one is the best option for a single example, but this requires manual curreation, is time consuming, not within the scope of this project and can be quite difficult. There are about 2000 of these terms. SNOMED US names are in UMLS, so those ambiguously mapping names are added by either the UMLS or SNOMED team. Perhaps in future versions, this is corrected at either UMLS or SNOMED level.\n",
+    "3. Ignoring the name is the easiest option and will not lead to potential difficult downstream interpretation. The drawback is that the name, which in this example is unique to SNOMED NL, will not be in the final Dutch UMLS table.\n",
+    "\n",
+    "Currently, we dediced to skip ambiguously mapping terms."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f92a681",
+   "id": "944cb580",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2477d83e",
+   "id": "90d86982",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71580c8c",
+   "id": "d27ae809",
    "metadata": {},
    "source": [
     "## Merge SNOMED Dutch with UMLS Dutch"
@@ -514,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a09beb7f",
+   "id": "78158388",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,6 +661,8 @@
     "    if snomed_id in unambiguous_mapping_ids:\n",
     "        cui = snomed_to_umls_mapping[snomed_id][0]\n",
     "        snomed_names_to_add.append([cui, row['str'], row['tty']])\n",
+    "    else:\n",
+    "        snomed_names_to_skip.append([snomed_id, row['str'], row['tty']])\n",
     "        \n",
     "# Create lists to fill with SNOMED names and their UMLS CUIs\n",
     "snomed_names_to_add = list()\n",
@@ -537,17 +677,9 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "89c50914",
-   "metadata": {},
-   "source": [
-    "### Example of skipped names"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6593b9fd",
+   "id": "9e369e83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,18 +690,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84c34950",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snomed_names_with_cui[snomed_names_with_cui.cui == 'C0078777']"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "0933494c",
+   "id": "212f098e",
    "metadata": {},
    "source": [
     "### Remove duplicate SNOMED concepts\n",
-    "Multiple SNOMED concepts can map to a single UMLS concept."
+    "Earlier the problem was discussed of a SNOMED term that maps to multiple UMLS concepts. There's also the problem of snomed names that are ambiguous in SNOMED itself. Some of these, like \"abces\" are not ambiguous in UMLS. So when mapping these concepts to UMLS, the ambiguity is solved."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb03eaa7",
+   "id": "b2a4193f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ee2ed30",
+   "id": "e047b944",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42170bb6",
+   "id": "6f2ae1f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,7 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95efe9f1",
+   "id": "ddb00ea5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,11 +751,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d39169d5",
+   "id": "57c9c83a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'Number of duplicate SNOMED names: {snomed_names_with_cui.shape[0]}')\n",
+    "print(f'Number of SNOMED concepts that include names that are ambiguous in SNOMED: {snomed_names_with_cui.shape[0]}')\n",
     "snomed_names_with_cui = snomed_names_with_cui.drop_duplicates(subset=['cui', 'str', 'sab', 'tty'], keep='first').reset_index(drop=True)\n",
     "print(f'Number of SNOMED names: {snomed_names_with_cui.shape[0]}')\n",
     "snomed_names_with_cui[snomed_names_with_cui.cui == 'C0000833']"
@@ -621,7 +763,48 @@
   },
   {
    "cell_type": "markdown",
-   "id": "673e96a9",
+   "id": "28672019",
+   "metadata": {},
+   "source": [
+    "### Clean SNOMED names\n",
+    "Some names from SNOMED are also in Title-format, such as ziekte van Parkinson. To prevent duplication, lowercase these terms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df8d4bf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(snomed_names_with_cui[snomed_names_with_cui.cui.isin(['C0030567', 'C0002736'])])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8707247a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snomed_names_with_cui['str'] = snomed_names_with_cui['str'].apply(convert_title_to_lowercase, split_char=' ')\n",
+    "snomed_names_with_cui['str'] = snomed_names_with_cui['str'].apply(convert_title_to_lowercase, split_char='-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9066e31a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Examples\n",
+    "display(snomed_names_with_cui[snomed_names_with_cui.cui.isin(['C0030567', 'C0002736'])])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "200038dd",
    "metadata": {},
    "source": [
     "### Concatenate SNOMED names to UMLS table"
@@ -630,54 +813,75 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "526f1b84",
+   "id": "56fcf1eb",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Add SNOMED names to UMLS\n",
     "dutch_umls_snomed = pd.concat([dutch_umls, snomed_names_with_cui])\n",
-    "print(f'Number of Dutch names in UMLS + SNOMED table: {dutch_umls_snomed.shape[0]}')"
+    "print(f'Number of Dutch names in UMLS + SNOMED table: {dutch_umls_snomed.shape[0]}')\n",
+    "\n",
+    "dutch_umls_snomed.sort_values(by=['cui', 'tty', 'sab', 'str'], ascending=[True, False, True, True], inplace=True)\n",
+    "dutch_umls_snomed.loc[dutch_umls_snomed.cui == 'C0030567']"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d74b98d8",
+   "id": "f70c8618",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# a = dutch_umls_snomed.groupby(['cui', 'str', 'tty'])['sab'].apply('|'.join).reset_index().copy()\n",
+    "\n",
+    "# dutch_umls_snomed.groupby(['cui', 'str']).agg({'sab' : '|'.join, 'tty' : '|'.join})  \n",
+    "a = dutch_umls_snomed.groupby(['cui', 'str'], as_index=False).agg({'sab' : '|'.join, 'tty' : '|'.join})  \n",
+    "# a.head(25)\n",
+    "a.loc[a.cui == 'C0030567']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91d4cd8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def replace_tty(tty):\n",
+    "    if 'P' in tty:\n",
+    "        return 'P'\n",
+    "    return 'A'\n",
+    "a.tty = a.tty.apply(replace_tty)\n",
+    "a.loc[a.cui == 'C0030567']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "479d6591",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Grouping rows on SAB\n",
-    "dutch_umls_snomed = dutch_umls_snomed.groupby(['cui', 'str', 'tty'])['sab'].apply('|'.join).reset_index()\n",
-    "print(f'Number of names after merging rows on SAB: {dutch_umls_snomed.shape[0]}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e75cc86e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Sort on CUI and TTY\n",
-    "dutch_umls_snomed.sort_values(by=['cui', 'tty', 'sab', 'str'], ascending=[True, False, True, True], inplace=True)\n",
+    "dutch_umls_snomed = dutch_umls_snomed.groupby(['cui', 'str'], as_index=False).agg({'sab' : '|'.join, 'tty' : '|'.join}).copy()\n",
+    "\n",
+    "# Make TTY nice\n",
+    "def replace_tty(tty):\n",
+    "    if 'P' in tty:\n",
+    "        return 'P'\n",
+    "    return 'A'\n",
+    "dutch_umls_snomed.tty = dutch_umls_snomed.tty.apply(replace_tty)\n",
+    "dutch_umls_snomed.sort_values(by=['cui', 'tty'], ascending=[True, False], inplace=True)\n",
     "dutch_umls_snomed.reset_index(drop=True,inplace=True)\n",
-    "dutch_umls_snomed[0:20]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4e721004",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# View some concepts that have are \"P\" in SNOMEDCT_NL and \"A\" in another SB \n",
-    "dutch_umls_snomed[dutch_umls_snomed.duplicated(subset=['cui', 'str'], keep=False)].head(10)"
+    "print(f'Number of names after merging rows on SAB: {dutch_umls_snomed.shape[0]}')\n",
+    "\n",
+    "# Check example\n",
+    "dutch_umls_snomed.loc[dutch_umls_snomed.cui == 'C0030567']"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5332c845",
+   "id": "7739ab69",
    "metadata": {},
    "source": [
     "## Remove problematic names\n"
@@ -686,23 +890,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c9f4ce5",
+   "id": "066966fd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "names_to_remove = ['Bij', # C0004923\n",
-    "                   'Bijen', # C0004923\n",
-    "                   'Haar', # C0018494\n",
+    "names_to_remove = ['bij', # C0004923\n",
+    "                   'bijen', # C0004923\n",
+    "                   'haar', # C0018494\n",
     "                   'bleek', # C0678215\n",
-    "                   'Weer', # C0043085\n",
-    "                   'Na+'] # C0337443\n",
+    "                   'weer', # C0043085\n",
+    "                   'na+'] # C0337443\n",
     "dutch_umls_snomed[dutch_umls_snomed.str.isin(names_to_remove)]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1c96ca5",
+   "id": "e8b0951f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +919,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f67ac04",
+   "id": "8fce1b91",
    "metadata": {},
    "source": [
     "## Add custom CUIs\n",
@@ -725,7 +929,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "667c8d5a",
+   "id": "baae037b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -735,7 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcb92c5d",
+   "id": "93933124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,7 +950,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89a6a53d",
+   "id": "d1427293",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,8 +960,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79a37f02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dutch_umls_snomed.head()"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "252eb37b",
+   "id": "c826b181",
    "metadata": {},
    "source": [
     "## Add TUI (types)\n",
@@ -767,7 +981,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f7b965b",
+   "id": "5f30e7d5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -782,7 +996,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c741fdf",
+   "id": "5bb08932",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -793,17 +1007,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a598431",
+   "id": "cd6997c3",
    "metadata": {},
    "source": [
     "## TUI Filtering\n",
-    "We could implement filtering of TUIs here. This depends on the domain and question of subsequent analysis. For SNOMED names there has been a seperate filtering step based on type, which is done in the notebook that creates the SNOMED concept table."
+    "What types of concepts (TUIs) should be removed depends on the domain and question of subsequent analysis. After assessing performance of named entity linking of these names on a few clinical documents, our team dediced to remove the following TUIs.\n",
+    "\n",
+    "SNOMED names are already filtered in a seperate filtering step based on type, which is done in the notebook that creates the SNOMED concept table."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23b21b41",
+   "id": "04778bfc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,7 +1056,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1eeaf3fd",
+   "id": "60d1cfaa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -854,7 +1070,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "670b7eda",
+   "id": "167caec2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -863,18 +1079,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7a8b3a34",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dutch_umls_snomed"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "8e9e235a",
+   "id": "ad56eaf3",
    "metadata": {},
    "source": [
     "### Update column names\n",
@@ -884,7 +1090,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87984b22",
+   "id": "9436af30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,17 +1100,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ff64c26",
+   "id": "00f6580e",
    "metadata": {},
    "source": [
     "## Add drug names\n",
-    "Only run this part below if you want to further expand the concept database with drug names, adds around 270k lines. We're not lowering drug names that start with a capital letter, since this can be a brand name."
+    "Only run this part below if you want to further expand the concept database with drug names, which adds around 270k lines. Many drugs only have an international name, or use the international name more often than the Dutch name, so adding these from ATC, Drugbank and RXNorm can be a good addition to the concept table. \n",
+    "\n",
+    "After assessing the resulting list it will be clear that many names will not be useful in named entity recognition, because they will probably never be used in natural language."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97470723",
+   "id": "385e18aa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -915,7 +1123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2063f5c0",
+   "id": "4edc4c91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -932,18 +1140,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c8f68ae",
+   "id": "8d58959a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the name got a preferred name from another vocab\n",
+    "# Convert title format to lowercase\n",
+    "drugs_original['name'] = drugs_original['name'].apply(convert_title_to_lowercase, split_char=' ')\n",
+    "drugs_original['name'] = drugs_original['name'].apply(convert_title_to_lowercase, split_char='-')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8b038a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drugs_original[drugs_original.cui =='C0020740']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "449e5dfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use previously defined preferred names.\n",
     "drugs_original['name_status'] = 'A'"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d965c9ba",
+   "id": "df6362d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,21 +1186,21 @@
     "\n",
     "dutch_umls_snomed_drugs = dutch_umls_snomed_drugs.groupby(['cui', 'name', 'name_status'])['ontologies'].apply('|'.join).reset_index()\n",
     "print(\"Records after merging ontologies in single value: \", len(dutch_umls_snomed_drugs))\n",
-    "dutch_umls_snomed_drugs"
+    "dutch_umls_snomed_drugs.head()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18a83a34",
+   "id": "86b2478b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add TUIs again\n",
+    "# Add TUI column\n",
     "dutch_umls_snomed_drugs = dutch_umls_snomed_drugs.merge(tui_original, how='left', on='cui')\n",
     "print(f'Number of rows containing TUIs: {dutch_umls_snomed_drugs.shape[0]}')\n",
     "\n",
-    "# Remove TUIs\n",
+    "# Remove TUIs that we decided to filter\n",
     "rows_to_remove = dutch_umls_snomed_drugs[dutch_umls_snomed_drugs.tui.isin(tuis_to_remove)].index\n",
     "dutch_umls_snomed_drugs = dutch_umls_snomed_drugs.drop(dutch_umls_snomed_drugs.index[rows_to_remove])\n",
     "print(f'Number of rows filtering TUIs: {dutch_umls_snomed_drugs.shape[0]}')\n",
@@ -980,16 +1210,55 @@
     "print(f'Number of rows after merging TUIs in single value: {dutch_umls_snomed_drugs.shape[0]}')\n",
     "\n",
     "# Rename TUI column to type_ids\n",
-    "dutch_umls_snomed_drugs.rename(columns={'tui': 'type_ids'}, inplace=True)\n",
+    "dutch_umls_snomed_drugs.rename(columns={'tui': 'type_ids'}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4d55e08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dutch_umls_snomed_drugs.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ad53b37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Grouping rows on SAB\n",
+    "print(f'Number of names before merging rows: {dutch_umls_snomed_drugs.shape[0]}')\n",
+    "dutch_umls_snomed_drugs = dutch_umls_snomed_drugs.groupby(['cui', 'name', 'type_ids'], as_index=False).agg({'ontologies' : '|'.join, 'name_status' : '|'.join}).copy()\n",
     "\n",
-    "# Sort values\n",
-    "dutch_umls_snomed_drugs = dutch_umls_snomed_drugs.sort_values(by=['cui', 'name_status', 'name', 'ontologies'], ascending=[True, False, True, True]).reset_index(drop=True)\n",
-    "dutch_umls_snomed_drugs.head(20)"
+    "# Make TTY nice\n",
+    "def replace_tty(tty):\n",
+    "    if 'P' in tty:\n",
+    "        return 'P'\n",
+    "    return 'A'\n",
+    "dutch_umls_snomed_drugs.name_status = dutch_umls_snomed_drugs.name_status.apply(replace_tty)\n",
+    "dutch_umls_snomed_drugs.sort_values(by=['cui', 'name_status'], ascending=[True, False], inplace=True)\n",
+    "dutch_umls_snomed_drugs.reset_index(drop=True,inplace=True)\n",
+    "print(f'Number of names after merging rows: {dutch_umls_snomed_drugs.shape[0]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6fa5bf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check example\n",
+    "dutch_umls_snomed_drugs.loc[dutch_umls_snomed_drugs.cui == 'C0020740']"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "52fdec7e",
+   "id": "c96d8881",
    "metadata": {},
    "source": [
     "## Saving"
@@ -998,7 +1267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e8d84e6",
+   "id": "b9b8fce9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1009,7 +1278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f279ad5f",
+   "id": "089e68a5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +1303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/dutch-umls_to_concept-table.ipynb
+++ b/dutch-umls_to_concept-table.ipynb
@@ -6,14 +6,19 @@
    "metadata": {},
    "source": [
     "# Dutch UMLS to concept table\n",
-    "This notebook describes how to convert a UMLS concept table containing Dutch terms, to a formatted concept table to be used in a tool such as MedCAT. In the second part of this notebook, we add drug names from Dutch SNOMED, because these concepts are not well represented in the Dutch UMLS source vocabularies. A large scale automatic mapping from SNOMED Dutch to UMLS is not possible because of many-to-many mapping, explained in this notebook.\n",
+    "This notebook describes how to convert a UMLS concept table containing Dutch terms, to a formatted concept table to be used in a tool such as MedCAT. In the second part of this notebook, names from Dutch SNOMED are added. In the third part, English drug names are added, because these concepts are not well represented in the Dutch UMLS source vocabularies. \n",
+    "\n",
+    "Mapping from SNOMED Dutch to UMLS can be difficult because of many-to-many mapping, explained in this notebook.\n",
     "\n",
     "Requirements:\n",
-    "- MySQL database containing Dutch UMLS terms\n",
+    "- UMLS MySQL database containing Dutch concepts\n",
     "\n",
-    "For adding Dutch SNOMED drug names:\n",
+    "For adding Dutch SNOMED names:\n",
     "- Dutch SNOMED concept tablel, created in `dutch-snomed_to_concept-table.ipynb`\n",
-    "- MySQL database containing SNOMED-US, which is used for mapping SNOMED Dutch -> UMLS"
+    "- UMLS MySQL database containing SNOMED-US, which is used for mapping SNOMED Dutch -> UMLS\n",
+    "\n",
+    "For adding English drug names:\n",
+    "- UMLS MySQL database containing drug ontologies such as RXNORM, ATC and Drugbank"
    ]
   },
   {
@@ -36,7 +41,7 @@
     "pd.set_option('max_colwidth', 400)\n",
     "\n",
     "# Set output version of the generated UMLS dutch concept table\n",
-    "UMLS_DUTCH_VERSION = 'v1.11-beta'\n",
+    "UMLS_DUTCH_VERSION = 'v1.11'\n",
     "\n",
     "# Set version of SNOMED to append to UMLS terms\n",
     "snomed_dutch_file = Path('04_ConceptDB') / 'snomedct-dutch_v1.3.csv'"
@@ -197,18 +202,18 @@
    "id": "075b53fa",
    "metadata": {},
    "source": [
-    "| TTY  | Description | Count | Example |\n",
-    "| - | - | - | - |\n",
-    "| LLT | Lower Level Term | 71603 | heupkombreuk, buikkramp|\n",
-    "| PT | Designated preferred name| 35746 | harthypertrofie, Pancoast-syndroom |\n",
-    "| MH | Main heading | 28618 | Dehydratie, Astma |\n",
-    "| SY | Designated synonym | 11859 | Spanningshoofdpijn, Ziekte van Hodgkin |\n",
-    "| HT | Hierarchical term | 3296 | calciummetabolismestoornissen, oculaire hemorragische aandoeningen |\n",
-    "| HG | High Level Group Term | 337 | complicaties geassocieerd met medisch hulpmiddel, zuur-basestoornissen |\n",
-    "| SMQ| Standardised MedDRA Query | 228| Leveraandoeningen (SMQ) , Tumormarkers (SMQ) |\n",
-    "| CP | ICPC component process (in original form) | 38 | Ander bloedonderzoek, Medicatie/recept/injectie |\n",
-    "| AB | Abbreviation in any source vocabulary | 27 | Infec, Neopl, Ear, Endo |\n",
-    "| OS | System-organ class | 27 | Bloed- en lymfestelselaandoeningen, Infecties en parasitaire aandoeningen |"
+    "| TTY  | Description | Example |\n",
+    "| - | - | - |\n",
+    "| LLT | Lower Level Term | heupkombreuk, buikkramp|\n",
+    "| PT | Designated preferred name | harthypertrofie, Pancoast-syndroom |\n",
+    "| MH | Main heading | Dehydratie, Astma |\n",
+    "| SY | Designated synonym | Spanningshoofdpijn, Ziekte van Hodgkin |\n",
+    "| HT | Hierarchical term | calciummetabolismestoornissen, oculaire hemorragische aandoeningen |\n",
+    "| HG | High Level Group Term  | complicaties geassocieerd met medisch hulpmiddel, zuur-basestoornissen |\n",
+    "| SMQ| Standardised MedDRA Query | Leveraandoeningen (SMQ) , Tumormarkers (SMQ) |\n",
+    "| CP | ICPC component process (in original form) | Ander bloedonderzoek, Medicatie/recept/injectie |\n",
+    "| AB | Abbreviation in any source vocabulary | Infec, Neopl, Ear, Endo |\n",
+    "| OS | System-organ class | Bloed- en lymfestelselaandoeningen, Infecties en parasitaire aandoeningen |"
    ]
   },
   {
@@ -608,13 +613,13 @@
    "id": "74cd0d86",
    "metadata": {},
    "source": [
-    "So SNOMED US has four names for 216004. Three of these names map to C1704268 and one maps to C0151836. In SNOMED NL, there is only one name for this concept. In our current UMLS table, we have 2 names for each UMLS concept. We could map the SNOMED name to both concepts (1), to a specific one (2), or ignore it (3):\n",
+    "So SNOMED US has four names for 216004. Three of these names map to C1704268 and one maps to C0151836. In SNOMED NL, there is only one name for this concept. In our current UMLS table, we have 2 names for each UMLS concept. We could map the SNOMED name to both concepts (1), to a specific one (2), or skip it (3):\n",
     "\n",
     "1. Mapping to both will cause ambiguity. It could have an effect on entity linking, or it could be solved during MedCAT's disambiguation functionality based on unsupervised training, but that depends on the synonyms and their presence in the training corpus. In this example there is only 1 Dutch SNOMED term, but when there are multiple Dutch SNOMED terms, adding all to both terms will lead to many duplicates.\n",
     "2. Mapping to a single one is the best option for a single example, but this requires manual curreation, is time consuming, not within the scope of this project and can be quite difficult. There are about 2000 of these terms. SNOMED US names are in UMLS, so those ambiguously mapping names are added by either the UMLS or SNOMED team. Perhaps in future versions, this is corrected at either UMLS or SNOMED level.\n",
-    "3. Ignoring the name is the easiest option and will not lead to potential difficult downstream interpretation. The drawback is that the name, which in this example is unique to SNOMED NL, will not be in the final Dutch UMLS table.\n",
+    "3. Skipping the name is the easiest option and will not lead to potential difficult downstream interpretation. The drawback is that the name, which in this example is not in any other Dutch ontology, will not be in the Dutch UMLS concept table.\n",
     "\n",
-    "Currently, we dediced to skip ambiguously mapping terms."
+    "Currently, approach #3 is used."
    ]
   },
   {
@@ -687,16 +692,6 @@
     "snomed_names_with_cui = pd.DataFrame(snomed_names_to_add, columns = ['cui', 'str', 'tty'])\n",
     "snomed_names_with_cui['sab'] = 'SNOMEDCT_NL'\n",
     "snomed_names_with_cui.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "84c34950",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "snomed_names_with_cui[snomed_names_with_cui.cui == 'C0078777']"
    ]
   },
   {
@@ -823,36 +818,6 @@
     "\n",
     "dutch_umls_snomed.sort_values(by=['cui', 'tty', 'sab', 'str'], ascending=[True, False, True, True], inplace=True)\n",
     "dutch_umls_snomed.loc[dutch_umls_snomed.cui == 'C0030567']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f70c8618",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# a = dutch_umls_snomed.groupby(['cui', 'str', 'tty'])['sab'].apply('|'.join).reset_index().copy()\n",
-    "\n",
-    "# dutch_umls_snomed.groupby(['cui', 'str']).agg({'sab' : '|'.join, 'tty' : '|'.join})  \n",
-    "a = dutch_umls_snomed.groupby(['cui', 'str'], as_index=False).agg({'sab' : '|'.join, 'tty' : '|'.join})  \n",
-    "# a.head(25)\n",
-    "a.loc[a.cui == 'C0030567']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "91d4cd8d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def replace_tty(tty):\n",
-    "    if 'P' in tty:\n",
-    "        return 'P'\n",
-    "    return 'A'\n",
-    "a.tty = a.tty.apply(replace_tty)\n",
-    "a.loc[a.cui == 'C0030567']"
    ]
   },
   {
@@ -1100,6 +1065,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db78d6e1",
+   "metadata": {},
+   "source": [
+    "### Save output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "897a1c0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print statistics\n",
+    "print(f'Unique concepts: {len(dutch_umls_snomed.cui.unique())}')\n",
+    "print(f'Unique names: {len(dutch_umls_snomed.name.unique())}')\n",
+    "print(f'Ambiguous names: {len(dutch_umls_snomed) - len(dutch_umls_snomed.name.unique())}')\n",
+    "print(f'Total names in concepts: {len(dutch_umls_snomed)}')\n",
+    "\n",
+    "# Save final concept table\n",
+    "dutch_umls_snomed.to_csv(f'04_ConceptDB/umls-dutch_{UMLS_DUTCH_VERSION}.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "00f6580e",
    "metadata": {},
    "source": [
@@ -1166,7 +1156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use previously defined preferred names.\n",
+    "# Use previously defined preferred names\n",
     "drugs_original['name_status'] = 'A'"
    ]
   },
@@ -1180,9 +1170,9 @@
     "# Merge drugs dataframe with umls_snomed dataframe\n",
     "dutch_umls_snomed_drugs = pd.concat([dutch_umls_snomed, drugs_original], axis=0)\n",
     "\n",
-    "print(\"UMLS_snomed lines: \", len(dutch_umls_snomed))\n",
-    "print(\"Drugs lines: \", len(drugs_original))\n",
-    "print(\"Adds up to: \", len(dutch_umls_snomed_drugs))\n",
+    "print(\"UMLS & SNOMED records: \", len(dutch_umls_snomed))\n",
+    "print(\"Drug name records: \", len(drugs_original))\n",
+    "print(\"Combined: \", len(dutch_umls_snomed_drugs))\n",
     "\n",
     "dutch_umls_snomed_drugs = dutch_umls_snomed_drugs.groupby(['cui', 'name', 'name_status'])['ontologies'].apply('|'.join).reset_index()\n",
     "print(\"Records after merging ontologies in single value: \", len(dutch_umls_snomed_drugs))\n",
@@ -1261,18 +1251,7 @@
    "id": "c96d8881",
    "metadata": {},
    "source": [
-    "## Saving"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b9b8fce9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Save final concept table\n",
-    "dutch_umls_snomed.to_csv(f'04_ConceptDB/umls-dutch_{UMLS_DUTCH_VERSION}.csv', index=False)"
+    "### Save output"
    ]
   },
   {
@@ -1282,6 +1261,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Print statistics\n",
+    "print(f'Unique concepts: {len(dutch_umls_snomed_drugs.cui.unique())}')\n",
+    "print(f'Unique names: {len(dutch_umls_snomed_drugs.name.unique())}')\n",
+    "print(f'Ambiguous names: {len(dutch_umls_snomed_drugs) - len(dutch_umls_snomed_drugs.name.unique())}')\n",
+    "print(f'Total names in concepts: {len(dutch_umls_snomed_drugs)}')\n",
+    "\n",
     "# Save final concept table with drugs\n",
     "dutch_umls_snomed_drugs.to_csv(f'04_ConceptDB/umls-dutch_{UMLS_DUTCH_VERSION}_with_drugs.csv', index=False)"
    ]


### PR DESCRIPTION
- Upgrade SNOMED to September 2022 release
- Upgrade UMLS to 2022AB release
- Remove descriptive text from names such as "; niet gespecificeerd"
- Remove `LNC-NL-NL` and `ICPC2ICD10DUT` sources terminologies, because they don't add anything for NER.
- Improve lowercasing and deduplication of title-names from UMLS (including drugnames) and SNOMED names
- Improve merging of duplicates rows, including solving #11
- Manual fix for `Ademhalingsinsufficiëntie` and `Respiratoire insufficiëntie, niet gespecificeerd` which had the wrong CUI mapping in ICD10DUT and MeSH and caused ambiguity.
- Added more documentation to explain decisions.

### UMLS ontologies & SNOMED
- Unique concepts: 254835
- Unique names: 569533
- Ambiguous names: 4942
- Total names in concepts: 574475

### Also add drug names
- Unique concepts: 367913
- Unique names: 749035
- Ambiguous names: 5291
- Total names in concepts: 754326

### Performance on Mantra GSC
| Dataset         | UMLS dutch  | Other changes              | F1 by char | F1 by cui |
|-----------------|-------------|----------------------------|------------|-----------|
| Nlwiki          | v1.8        |                            | 0.585      | 0.526     |
| Nlwiki+Ntvg+Dcc | v1.8        |                            | 0.588      | 0.524     |
| Nlwiki+Ntvg+Dcc | v1.8+drugs  |                            | 0.609      | 0.552     |
| Nlwiki+Ntvg+Dcc | v1.8+drugs  | Diacritics fix             | 0.616      | 0.549     |
| Nlwiki+Ntvg+Dcc | v1.8+drugs  | Diacritics & uppercase fix | 0.626      | 0.561     |
| Nlwiki+Ntvg+Dcc | v1.9+drugs  | Diacritics & uppercase fix | 0.632      | 0.564     |
| Nlwiki          | **v1.11+drugs** | Updated sources & cleaning | 0.628      | 0.557     |